### PR TITLE
Single Player: UI updates, local storage fixes, modal fixes, etc.

### DIFF
--- a/assets/js/singleplayer.js
+++ b/assets/js/singleplayer.js
@@ -1,21 +1,52 @@
+//On Load, check the local storage for existing games.
+window.addEventListener("load", (event) => {
+    // This may need to be its own separate function. For MVP, it's fine.
+    let spGames = getSPLocalStorage();
+    const dropdown = document.querySelector('#dropdown');
+    let spGameTitleList;
+    let spGameTitleListInterim = [];
+    if (spGames.length === 0) {
+        console.log("INFO: No Games Found. Add some to help this application achieve glorious domination!")
+    }else {
+        //Collect all the game titles
+        for (i = 0; i < spGames.length; i++){
+            spGameTitleListInterim.push(spGames[i].gameTitle);
+            //run a duplicate check
+            //Effectively, it appears any set MUST have unique values. Converting the array to a set and then back again removes the duplicates.
+            spGameTitleList = [... new Set(spGameTitleListInterim)];
+        }
+        //render to the game list. This may need to be its own separate function. For MVP, it's probably fine.
+        if (spGames.length === 0){
+            console.log("INFO: No Games Found. Add some to help this application achieve glorious domination!")
+        }else {
+            for (i = 0; i < spGameTitleList.length; i++){
+                const spGame = document.createElement('option')
+                spGame.textContent = spGameTitleList[i];
+                console.log (`INFO: spGame.textContent: ${spGame.textContent} should render to the screen`)
+                dropdown.appendChild(spGame);
+                spGame.setAttribute('id', `localstorage${i}`)
+        }
+
+        }
+    }
+})
+
 function getSPLocalStorage() {
-    //replaced key with hard coded 'items' value for single player. If we need to split SP/MP journal entries, we may need to split off SP/MP keys. Leo, can you think of a better way? Maybe object creation function returns a key somehow?
-    let journalEntry = JSON.parse(localStorage.getItem('sPItems'));
-    if (journalEntry === null) {
+
+    let spGames = JSON.parse(localStorage.getItem('spGames'));
+    if (!spGames) {
+        console.log ("INFO: No SP Games Found, should return empty array.")
         return [];
     }
-    return journalEntry;
+    return spGames;
 }
 
-function setSPLocalStorage(item) {
-    // Has no fail safe for NULL values
-    //JB: There should be a check on SP to prevent blank items from being entered. Depending on how many more key/value pairs there are it may be best to split that off into a different function
-    // check to see if local storage already has data.
-    let items = getSPLocalStorage();
+function setSPLocalStorage(spGame) {
+    let spGames = getSPLocalStorage();
     //push new item to items
-    items.push(item);
+    spGames.push(spGame);
     //save data to local storage after stringifying it.
-    localStorage.setItem('sPItems', JSON.stringify(items));
+    localStorage.setItem('spGames', JSON.stringify(spGames));
 }
 function domAppend(el, parent) {
     //append item to DOM using two arguments
@@ -27,49 +58,47 @@ function domAppend(el, parent) {
 function createSPDataObject(event) {
     event.preventDefault();
     console.log("INFO: createSPDataObject was called.")
-// This function takes input from the modal, creates and object and passes the information to setLocalStorage
-    // Setup query selectors
-const gameTitle = document.querySelector('#game-title');
-const rating = document.querySelector('#game-rating');
-//Placeholder for completed (boolean)
-//Placeholder for Prompt
-//Placeholder for other data that might come up?
-    if (gameTitle.value === "" || rating.value === ""){
-        // return error message -- 
-        const main = document.querySelector('main');
-        const paragraphEl = domAppend('p', main)
+    if (spGameTitleModal.value === "" || spGameRatingModal.value === ""){
+        // return error message on the modal
+        const modalBody = document.querySelector('#modal-body');
+        const paragraphEl = domAppend('p', modalBody)
         paragraphEl.setAttribute('id', 'error')
         const error = document.querySelector('#error')
         error.textContent = "Please complete the required fields."
     } else {
-        let sPJournalEntry = {
-            //this first key value pair is not working. TODO: Why is that? Is it because of the dash?
-            gameTitle : gameTitle.value,
-            rating : rating.value
-            //There will be more here. Feel free to add more key/value pairs
+        let spGame = {
+            gameTitle : spGameTitleModal.value,
+            rating : spGameRatingModal.value,
+            // TODO: how do I get the value of a radio button? It should go here.
+            comments : spGameComments.value
         };
-        setSPLocalStorage(sPJournalEntry);
-        return sPJournalEntry;
+        setSPLocalStorage(spGame);
+        //simply made available for future development if needed.
+        return spGame;
     }
 }
 
-//TODO: Change the event listener. This is simply to test the function
-let submitBtn = document.querySelector('#game-form')
-submitBtn.addEventListener('submit', createSPDataObject)
+
+//This is tied to the Modal Save button now.
+let saveBtn = document.querySelector('#spGameForm')
+saveBtn.addEventListener('submit', createSPDataObject)
 
 //Add button to dropdown menu
 const addGameBtn = document.querySelector('#add-game');
-const gameTitle = document.querySelector('#game-title');
+const gameTitle = document.querySelector('#gametitle');
 function addGame() {
     
     if (gameTitle.value !== "") {
         const dropdown = document.querySelector('#dropdown');
         const newGame = document.createElement('option');
+        const spGameTitle = document.querySelector('#spGameTitle')
         newGame.textContent = gameTitle.value;
         dropdown.appendChild(newGame);
-        document.querySelector('#game-title').value = "";
+        document.querySelector('#spGameTitle').value = "";
+        //JB Additions: Future development, perhaps or code cleanup.
+        return spGameTitle;
     } else {
         alert("Please enter a game title.")
     }
 }
-    addGameBtn.addEventListener('click', addGame);
+    addGameBtn.addEventListener('click', addGame); 

--- a/assets/style.css
+++ b/assets/style.css
@@ -139,3 +139,6 @@ footer {
         width: 100%;
     }
 }
+#error {
+    color:red;
+}

--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
     <header>
         <h1>The Gamer's Journal</h1>
 
-            <input type="text" id="game-title" placeholder="Enter game here">
-            <select name="games" id="dropdown">
+            <input type="text" id="gametitle" placeholder="Enter game here">
+            <select name="spGames" id="dropdown">
                 <option value="default">--Select a game--</option>
             </select>
             <button id="add-game" type="button">Add</button>
@@ -27,19 +27,11 @@
     </header>
     <main>
         <section>
-            <form action="" id="game-form">
-                <label for="game-title" id="spGameTitle">Game title:</label>
-                <input type="text" id="game-title" name="game-title">
-                <label for="rating"> Rating:</label>
-                <input type="text" id="game-rating">
-            </form>
-        </section>
-        <section>
-            <form action="" id="game-stats">
-                <label for="record">Win/Loss</label>
-                <input type="text" id="stats" name="">
-                <label type="submit">Video Link:</label>
-                <input type="text" id="video-link">
+            <form action="" id="spGameForm">
+                <label for="spGameTitle" id="spGameTitle">Game title:</label>
+                <input type="text" id="spGameTitle" name="spGameTitle">
+                <label for="spGameRating">Rating:</label>
+                <input type="text" id="spGamerating">
                 <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">Journal</button>
                     <div class="modal fade" data-bs-theme="dark" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
                         <div class="modal-dialog modal-dialog-scrollable" data-bs-theme="dark">
@@ -48,29 +40,29 @@
                               <h1 class="modal-title fs-5" id="exampleModalLabel">Journal</h1>
                               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                             </div>
-                            <div class="modal-body" data-bs-theme="dark">
+                            <div class="modal-body" data-bs-theme="dark" id="modal-body">
                                 <!-- FIXME: DIRTY HACKY CODE -->
                                 <label for="gameNameModal">Game Title</label><br>
-                                <input type="text" name="gameNameModal" id="gameNameModal"/><br>
+                                <input type="text" name="spGameTitleModal" id="spGameTitleModal"/><br>
                                 <label for="ratingModal">Rating</label><br>
-                                <input type="text" name="ratingModal" id="ratingModal"/>
+                                <input type="text" name="spGameRatingModal" id="spGameRatingModal"/>
                                 <p>Have you beaten this game?</p>
-                                <input type="radio" id="gameCompletedYes" name="gameCompleted" value="yes">
+                                <input type="radio" id="sPgameCompletedYes" name="spGameCompleted" value="yes">
                                 <label for="gameCompletedYes">Yes</label><br>
-                                <input type="radio" id="gameCompletedNo" name="gameCompleted" value="no">
-                                <label for="gameCompletedNo">No</label><br>
-                                <label for="journalEntryModal">Comments:</label>
-                                <textarea class="form-control" rows="5" id="journalEntryModal" name="Journal"></textarea>
+                                <input type="radio" id="spGameCompletedNo" name="spGameCompleted" value="no" checked="checked">
+                                <label for="spGameCompletedNo">No</label><br>
+                                <label for="spGameComments">Comments:</label>
+                                <textarea class="form-control" rows="5" id="spGameComments" name="spGameComments"></textarea>
                             </div>
                             <div class="modal-footer">
                               <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                              <button type="button" class="btn btn-primary">Save</button>
+                              <button type="submit" class="btn btn-primary" id ="spSaveButton">Save</button>
                             </div>
                           </div>
                         </div>
                       </div>
+                    </section>
             </form>
-    </section>
     </main>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="./assets/js/singleplayer.js"></script>


### PR DESCRIPTION
## Change Log
NOTE: This is all within context of Single Player
- Removed Win Loss
- Removed Video Link
- cleaned up labels for SP
- Mostly fixed Dropbown button after label, name changes
- added error CSS for when there is a blank value.
- added checking for blanks to the Modal
- Save changes now functions to save a full entry.
- When the page loads, the page will now check localStorage for any existing games. If it finds them, it will load to the list.
	- Additionally, It will only have unique game titles.

	- TODO: Move this off into separate functions. This onLoad function is doing a LOT of heavy lifting and probably shouldn't be.

## Known Bugs still present
- Possible bug: Value did not clear after entry. This may be due to a regression I introduced, but I'm not certain.
- Still need to figure out how to make sure game title adds to local storage. Presently, you can go to the Modal and add that way, but you should also be able to do that. (My problem to solve.)
- Data still needs to render to the screen
- There is a minor bug where if the user enters a new title from the Modal, they will need to refresh for that to appear in the list.
- CSS: Still haven't looked into the background image yet. It's on my list, but only once I've got MVP stuff done on my side.

Testing:
- Tested and should be working, but let me know if you find something.